### PR TITLE
Build package for multiple Python flavors on the SLE15 family

### DIFF
--- a/package/zypp-plugin.changes
+++ b/package/zypp-plugin.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Feb 17 16:25:05 UTC 2025 - Pablo Suárez Hernández <psuarezhernandez@suse.com>
+
+- Build package for multiple Python flavors on the SLE15 family
+
+-------------------------------------------------------------------
 Mon Jul 15 15:51:49 CEST 2024 - ma@suse.com
 
 - Fix stomp header regex to include '-' (bsc#1227793)

--- a/package/zypp-plugin.spec
+++ b/package/zypp-plugin.spec
@@ -29,7 +29,12 @@ Source0:        %{name}-%{version}.tar.bz2
 BuildArch:      noarch
 
 %if %{singlespec_py3}
+if 0%{?suse_version} >= 1500
+%{?sle15allpythons}
+%else
 %{?!python_module:%define python_module() python-%{**} python3-%{**}}
+%endif
+
 BuildRequires:  %{python_module devel}
 BuildRequires:  python-rpm-macros
 BuildRequires:  fdupes


### PR DESCRIPTION
This PR makes the package to build for all different flavors on the SLE15 family:

### SLE version < 15SP4:
- `python2-zypp-plugin`
- `python3-zypp-plugin`

### SLE version >= 15SP4:

- `python3-zypp-plugin`
- `python311-zypp-plugin`

Before this PR, in case of SLE version >= 15SP4, this spec file was only building `python3-zypp-plugin` flavor.